### PR TITLE
Fix gatsby 4 bug & bump peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "p-map": "^2.0.0"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -61,7 +61,7 @@ const relativizeJsFiles = async () => {
         // e.g.: return"__GATSBY_IPFS_PATH_PREFIX__/static/..." -> return __GATSBY_IPFS_PATH_PREFIX + "/static/..."
         contents = contents
         .replace(/["']\/__GATSBY_IPFS_PATH_PREFIX__['"]/g, () => ' __GATSBY_IPFS_PATH_PREFIX__ ')
-        .replace(/(["'])\/__GATSBY_IPFS_PATH_PREFIX__\/([^'"]*?)(['"])/g, (matches, g1, g2, g3) => ` __GATSBY_IPFS_PATH_PREFIX__ + ${g1}/${g2}${g3}`);
+        .replace(/(?<!\\)(["'])\/__GATSBY_IPFS_PATH_PREFIX__\/([^'"]*?)(['"])/g, (matches, g1, g2, g3) => ` __GATSBY_IPFS_PATH_PREFIX__ + ${g1}/${g2}${g3}`);
 
         contents = `if(typeof __GATSBY_IPFS_PATH_PREFIX__ === 'undefined'){__GATSBY_IPFS_PATH_PREFIX__=''}${contents}`;
 


### PR DESCRIPTION
In Gatsby 4 there's a "__GATSBY_IPFS_PATH_PREFIX__" in an error logging string that gets replaced in a way that breaks the string and causes an error.

That error is logged in the console as `Uncaught SyntaxError: missing ) after argument list`

This is the (built & replaced) code that caused the error:

<img width="513" alt="image" src="https://user-images.githubusercontent.com/9130691/197872717-78512cdb-0fba-4b79-aac6-4479a660a962.png">

Not replacing the \"__GATSBY_IPFS_PATH_PREFIX__" if the " is escaped with \ fixes the issue.

This is the (built & replaced) code after the fix is applied:

<img width="527" alt="image" src="https://user-images.githubusercontent.com/9130691/197880834-f261b808-bad9-475a-995f-5e16a67fd440.png">

The fixed bug is mentioned in this issue: https://github.com/moxystudio/gatsby-plugin-ipfs/issues/25
